### PR TITLE
back permission into the image (

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ ARG WEBLATE_VERSION="latest"
 
 FROM weblate/weblate:${WEBLATE_VERSION}
 
-# USER root
-# RUN mkdir -p /tmp/run/supervisor.conf.d \
-#     && chmod -R 1777 /tmp/run \
-#     && ln -s /tmp/run /run
-#USER weblate
+USER root
+RUN chmod 1777 /tmp
+USER weblate


### PR DESCRIPTION
It avoids requiring a mounted volume in the ECS task definition.