### PR TITLE
Add S3 support for Django

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ FROM weblate/weblate:${WEBLATE_VERSION}
 USER root
 # single quotes wanted in sed cmd
 # hadolint ignore=SC2016
+# Install pip into Weblate's venv if missing, then django-storages (to allow S3 support)
 RUN chmod 1777 /tmp \
-    && sed -i 's|\([0-9][0-9]*\)/\(healthz\)|\1${WEBLATE_URL_PREFIX}/\2|' /app/bin/health_check
+    && sed -i 's|\([0-9][0-9]*\)/\(healthz\)|\1${WEBLATE_URL_PREFIX}/\2|' /app/bin/health_check \
+    && /app/venv/bin/python3 -m ensurepip \
+    && /app/venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && /app/venv/bin/pip install --no-cache-dir django-storages[boto3]
 USER weblate


### PR DESCRIPTION
Add missing package.
Note `boto3` seems already installed (while `pip` was stripped out to slim down the image):
```
root@ip-10-75-43-44:/# /app/venv/bin/python3 -m pip
/app/venv/bin/python3: No module named pip
root@ip-10-75-43-44:/# /app/venv/bin/python3 - <<'PYCODE'
> try:
>     import boto3
>     print("✅ boto3 available")
> except ImportError:
>     print("❌ boto3 missing")
>
> try:
>     import storages
>     print("✅ django-storages available")
> except ImportError:
>     print("❌ django-storages missing")
> PYCODE
✅ boto3 available
❌ django-storages missing

```